### PR TITLE
chore: CI과정에서 build 테스트 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: Spring Boot CI
+
+on:
+  pull_request:
+    branches: [ main, dev ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Grant execute permission for Gradle wrapper
+        run: chmod +x ./gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      - name: Run tests
+        run: ./gradlew test


### PR DESCRIPTION
## 🛠️ 작업 개요
Spring Boot 프로젝트에서 PR 생성 시 빌드 및 테스트를 자동화하기 위해 GitHub Actions CI 파이프라인을 설정했습니다.

## 📝 관련 이슈
Closes #6

## 📋 변경 내용
- `.github/workflows/ci.yml` 파일 생성
- Java 21 + Gradle 기반 프로젝트에 맞춰 빌드 및 테스트 수행
- PR 시점에 `build` 및 `test` 단계가 자동으로 실행되도록 설정
- 향후 branch protection 설정에서 필수 체크로 활용 가능

## ✅ 체크리스트
- [x] Docker 컨테이너가 정상적으로 실행되는지 확인함
- [x] 기존 기능에 영향 없음
